### PR TITLE
Video formatting on mobile is less broken

### DIFF
--- a/content/blog/2024-02-23.md
+++ b/content/blog/2024-02-23.md
@@ -91,14 +91,14 @@ For those wondering, `FNFC` files are our new standard for developing charts, cr
 
 The grid area itself is divided up into measures and beats to help orient yourself while scrolling. The bright red playhead in the middle represents your actual position in the song and can be moved by clicking and dragging in the time ticks on the left side, or by holding ALT while scrolling. Pressing SPACE will smoothly scroll the grid as the song plays. With regards to keyboard shortcuts, there's probably several dozen, to where nearly every option has an associated keyboard shortcut, so you can navigate around and do work without having to move your hand constantly from the mouse to the keyboard. There is also an optional "Live Input" mode, which lets you place notes at the playhead with WASD/Up-Down-Left-Right. Notes placed this way (or with the mouse) will use the current snap setting you've defined, so you could easily chart a section of 24th notes by placing the playhead at the top, tapping out some notes, and then proofreading after.
 
-<video src="/img/chart-editor-copy-paste.mp4" controls="controls" style="max-width: 730px;">
+<video src="/img/chart-editor-copy-paste.mp4" controls="controls">
 </video>
 
 *Conveniences like dragging notes to move them and Ctrl-F to flip makes copying sections more intuitive.*
 
 A big feature I haven't talked about yet is the Song Events feature, which vastly improves how we create charts and will become even better in the future. Song Events are manipulated in the ninth column on the right side, and don't appear as notes on either player's strumline. Instead, an appropriate chunk of code gets run when the event is hit. The main thing it's used for right now is camera control; previously, camera movement was tied to specific sections, but you can now focus the camera on either character (or Girlfriend, or a specific position on the stage!) whenever you like. There's only a couple built-in events right now (such as one that triggers a character or stage prop to play an animation) but this system is very extensible and mods can add new ones, so I expect to see people implementing Blammed Lights with it very quickly.
 
-<video src="/img/chart-editor-events-toolbox.mp4" controls="controls" style="max-width: 730px;">
+<video src="/img/chart-editor-events-toolbox.mp4" controls="controls">
 </video>
 
 *The form under the dropdown is generated dynamically using data provided by the event type!*

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -13,5 +13,6 @@ main .container {
 }
 
 video {
-    max-width: 90%;
+    width: 100%; 
+    height: auto; 
 }

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -11,3 +11,7 @@ main .container {
     padding-top: -10px;
     margin-top: 0;
 }
+
+video {
+    max-width: 90%;
+}


### PR DESCRIPTION
On mobile (or small screens) video elements are too long and render empty space on the right side of the page 
Also i made it 90% max width and not 100% because of padding