### PR TITLE
Make all blog previews 100% width

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -29,3 +29,7 @@ video {
     width: 100%; 
     height: auto; 
 }
+
+section a {
+    width: 100%;
+}


### PR DESCRIPTION
The blog previews on funkin.me were different sizes depending on how much content they had so I just made it force 100% width on all of them:

![image](https://github.com/FunkinCrew/funkBlog/assets/47027981/6a553044-9f6e-4d8c-94e5-7f3f73315959)

Hopefully doesn't break any other elements? I did a quick look around and nothing seemed broken but I'm not sure.