### PR TITLE
Repointing img link to "funkin.me" | attempt to fix recent March blog

### DIFF
--- a/content/blog/2024-03-03.md
+++ b/content/blog/2024-03-03.md
@@ -16,7 +16,7 @@ The feedback on last week's blog post has been absolutely wonderful. I'm sure a 
 
 My main task for this week was... whoopsie! That's classified! That happens a lot, but unlike the last five months where I therefore would have nothing to say and therefore nothing to contribute to the blog, I can instead use the chart editor as an endless source of little discussion topics!
 
-[![chart-editor-crash-recovery](https://github-production-user-asset-6210df.s3.amazonaws.com/22229331/309529823-0dd87f84-63c1-433a-9387-0ed61ea53ce0.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240303T064519Z&X-Amz-Expires=300&X-Amz-Signature=9685ab7dc904f8478de869a355d103c5f94d085ce9a48f518e04a6e27f963a17&X-Amz-SignedHeaders=host&actor_id=22229331&key_id=0&repo_id=587487847)](https://youtu.be/kU0SmxKucCw)
+[![chart-editor-crash-recovery](https://funkin.me/img/2024-02-23/chart-editor-crash-recovery.png)](https://youtu.be/kU0SmxKucCw)
 
 Hey wait, I showed you this image last week! However, I was being cheeky, and didn't talk much about what this feature actually does for you!
 


### PR DESCRIPTION
I don't know what the amazon link is for, but can't you guys just use "https://funkin.me/img/2024-02-23/chart-editor-crash-recovery.png" instead?