### PR TITLE
fix(docs): readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ for generation, and [Pico CSS](https://picocss.com/) for styling.
   manager!
 - We get Pico CSS from NPM, so you need to [install node](https://nodejs.org) if
   you don't already have it.
-  - Then you can just `npm install` to get Pico CSS
+  - Then you can just `npm ci` to get Pico CSS
 
 # Running the site
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,27 @@
 # funkin.me source code
 
-This is the source code repository for the FUNKIN CREW WEBSITE, [`funkin.me`](https://funkin.me)
+This is the source code repository for the FUNKIN CREW WEBSITE,
+[`funkin.me`](https://funkin.me)
 
-It is a static site generated website, using [Zola](https://www.getzola.org/) for generation, and [Pico CSS](https://picocss.com/) for styling.
+It is a static site generated website, using [Zola](https://www.getzola.org/)
+for generation, and [Pico CSS](https://picocss.com/) for styling.
 
 # Setup
 
-- Installation instrucitons for [zola are here](https://www.getzola.org/documentation/getting-started/installation/). It is just a binary file you either add to your path, or install via package manager!
-- We get Pico CSS from NPM, so you need to [install node](https://nodejs.org) if you don't already have it.
-    - Then you can just `npm install` to get Pico CSS
+- Installation instrucitons for
+  [zola are here](https://www.getzola.org/documentation/getting-started/installation/).
+  It is just a binary file you either add to your path, or install via package
+  manager!
+- We get Pico CSS from NPM, so you need to [install node](https://nodejs.org) if
+  you don't already have it.
+  - Then you can just `npm install` to get Pico CSS
 
 # Running the site
 
-From the [Zola CLI usage docs](https://www.getzola.org/documentation/getting-started/cli-usage/)
+From the
+[Zola CLI usage docs](https://www.getzola.org/documentation/getting-started/cli-usage/)
+
 > [Zola only has 4 commands: `init`, `build`, `serve` and `check`.](https://www.getzola.org/documentation/getting-started/cli-usage/)
 
-So you just need to run `zola serve` to compile and run the site on a local web server.
-
-
+So you just need to run `zola serve` to compile and run the site on a local web
+server.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for generation, and [Pico CSS](https://picocss.com/) for styling.
 
 # Setup
 
-- Installation instrucitons for
+- Installation instructions for
   [zola are here](https://www.getzola.org/documentation/getting-started/installation/).
   It is just a binary file you either add to your path, or install via package
   manager!


### PR DESCRIPTION
- lint
- fixed typo
- `npm ci` should always be preferred when cloning a project; it's faster & doesn't touch the package-lock.json