### PR TITLE
Get rid of PicoCSS install step in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ for generation, [Tailwind CSS](https://tailwindcss.com/) for styling, and [Iconi
   [zola are here](https://www.getzola.org/documentation/getting-started/installation/).
   It is just a binary file you either add to your path, or install via package
   manager!
-- We get Pico CSS from NPM, so you need to [install node](https://nodejs.org) if
-  you don't already have it.
-  - Then you can just `npm ci` to get Pico CSS
+- You need to [install node](https://nodejs.org) if you don't already have it.
 
 # Running the site
 


### PR DESCRIPTION
PicoCSS seems to have been eradicated from the repo in https://github.com/FunkinCrew/funkBlog/commit/da958852a8026dcb59611202567099827ad2fc4a, so we don't need the install step anymore