### PR TITLE
Fix table of contents not closing

### DIFF
--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -63,7 +63,7 @@
   }}
 
   <script>
-    const toc = document.getElementsByClassName('sticky-toc')[0];
+    const toc = document.getElementsByClassName('sticky toc')[0];
     const close_toc = () => toc.open = false;
 
     const h1 = document.getElementsByTagName('h1');


### PR DESCRIPTION
The table of contents' class name is `sticky toc`, not `sticky-toc`. This caused the `toc` variable to be undefined, which lead to the `close_toc()` method failing and the table of contents not closing!

<img width="465" height="87" alt="image" src="https://github.com/user-attachments/assets/f1ed138c-aa24-4c4b-afcf-2a297a23278f" />
