### PR TITLE
Add a "modding documentation" link to the base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -55,6 +55,10 @@
       <a href="{{ get_url(path='@/kickstarter-support/_index.md') }}" class="text-gray-50">
         Kickstarter Support
       </a>
+      <a href="https://thekade.net/funkin-cookbook" target="_blank" class="text-gray-50">
+        Modding Documentation
+        <i class="sm i-mdi-open-in-new"></i>
+      </a>
       <a href="{{ get_url(path='@/blog/_index.md') }}" class="text-gray-50">Blog</a>
       <a href="/atom.xml">
         <i class="i-mdi-rss"></i>


### PR DESCRIPTION
Cookbook real, maybe.
<img width="2552" height="1308" alt="image" src="https://github.com/user-attachments/assets/72e6801c-fb18-4e53-813e-7be432b90a3e" />
